### PR TITLE
Tt h legacy analysis variable binning

### DIFF
--- a/configs/combined_ttb_bb_other_jettag_cats.py
+++ b/configs/combined_ttb_bb_other_jettag_cats.py
@@ -9,6 +9,8 @@ sys.path.append(basedir)
 
 import util.tools.plotClasses as plotClasses
 import ROOT
+from array import array
+from copy import deepcopy
 
 
 
@@ -252,172 +254,733 @@ def plots_ge4j_ge3t():
 
 
 def plots_dnn(data, discrname):
-    categories = []
-    nhistobins = []
-    minxvals = []
-    maxxvals = []
-    discrs = []
 
     ndefaultbins = 15
+    category_dict = {}
+    this_dict = {}
 
 
 
 
     # plots for ge4j_3t
-    categories += [
-        ("((N_Jets>=4&&N_BTagsM==3)&&DNNPredictedClass_ge4j_3t==0)","ljets_ge4j_3t_ttH_node",""),
-        ("((N_Jets>=4&&N_BTagsM==3)&&DNNPredictedClass_ge4j_3t==1)","ljets_ge4j_3t_ttb_bb_node",""),
-        ("((N_Jets>=4&&N_BTagsM==3)&&DNNPredictedClass_ge4j_3t==2)","ljets_ge4j_3t_tt2b_node",""),
-        ("((N_Jets>=4&&N_BTagsM==3)&&DNNPredictedClass_ge4j_3t==3)","ljets_ge4j_3t_ttcc_node",""),
-        ("((N_Jets>=4&&N_BTagsM==3)&&DNNPredictedClass_ge4j_3t==4)","ljets_ge4j_3t_ttlf_node",""),
-        ]
-    discrs += [
-        "DNNOutput_ge4j_3t_node_ttH",
-        "DNNOutput_ge4j_3t_node_ttb_bb",
-        "DNNOutput_ge4j_3t_node_tt2b",
-        "DNNOutput_ge4j_3t_node_ttcc",
-        "DNNOutput_ge4j_3t_node_ttlf",
-        ]
-    nhistobins += [ndefaultbins, ndefaultbins, ndefaultbins, ndefaultbins, ndefaultbins]
-    minxvals += [0.2, 0.2, 0.2, 0.2, 0.2]
-    maxxvals += [0.83, 0.66, 0.75, 0.42, 0.65]
 
-
-
+    category_dict["category"] = ("((N_Jets>=4&&N_BTagsM==3)&&DNNPredictedClass_ge4j_3t==0)","ljets_ge4j_3t_ttH_node","")
+    category_dict["discr"] = "DNNOutput_ge4j_3t_node_ttH"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1775,
+				0.2225,
+				0.2675,
+				0.3125,
+				0.3575,
+				0.4025,
+				0.4475,
+				0.4925,
+				0.5375,
+				0.5825,
+				0.6275,
+				0.6725,
+				0.7175,
+				0.7625,
+				0.8075,
+				0.83 
+			]
+    this_dict["ljets_ge4j_3t_ttH_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets>=4&&N_BTagsM==3)&&DNNPredictedClass_ge4j_3t==1)","ljets_ge4j_3t_ttb_bb_node","")
+    category_dict["discr"] = "DNNOutput_ge4j_3t_node_ttb_bb"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1836,
+				0.2164,
+				0.2493,
+				0.2821,
+				0.315,
+				0.3479,
+				0.3807,
+				0.4136,
+				0.4464,
+				0.4793,
+				0.5121,
+				0.545,
+				0.5779,
+				0.6107,
+				0.6436,
+				0.66 
+			]
+    this_dict["ljets_ge4j_3t_ttb_bb_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets>=4&&N_BTagsM==3)&&DNNPredictedClass_ge4j_3t==2)","ljets_ge4j_3t_tt2b_node","")
+    category_dict["discr"] = "DNNOutput_ge4j_3t_node_tt2b"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1804,
+				0.2196,
+				0.2589,
+				0.2982,
+				0.3375,
+				0.3768,
+				0.4161,
+				0.4554,
+				0.4946,
+				0.5339,
+				0.5732,
+				0.6125,
+				0.6518,
+				0.6911,
+				0.7304,
+				0.75 
+			]
+    this_dict["ljets_ge4j_3t_tt2b_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets>=4&&N_BTagsM==3)&&DNNPredictedClass_ge4j_3t==3)","ljets_ge4j_3t_ttcc_node","")
+    category_dict["discr"] = "DNNOutput_ge4j_3t_node_ttcc"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1921,
+				0.2079,
+				0.2236,
+				0.2393,
+				0.255,
+				0.2707,
+				0.2864,
+				0.3021,
+				0.3179,
+				0.3336,
+				0.3493,
+				0.365,
+				0.3807,
+				0.3964,
+				0.4121,
+				0.42 
+			]
+    this_dict["ljets_ge4j_3t_ttcc_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets>=4&&N_BTagsM==3)&&DNNPredictedClass_ge4j_3t==4)","ljets_ge4j_3t_ttlf_node","")
+    category_dict["discr"] = "DNNOutput_ge4j_3t_node_ttlf"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1839,
+				0.2161,
+				0.2482,
+				0.2804,
+				0.3125,
+				0.3446,
+				0.3768,
+				0.4089,
+				0.4411,
+				0.4732,
+				0.5054,
+				0.5375,
+				0.5696,
+				0.6018,
+				0.6339,
+				0.65 
+			]
+    this_dict["ljets_ge4j_3t_ttlf_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
 
 
     # plots for le5j_ge3t
-    categories += [
-        ("((N_Jets<=5&&N_BTagsM>=3)&&DNNPredictedClass_le5j_ge3t==0)","ljets_le5j_ge3t_ttH_node",""),
-        ("((N_Jets<=5&&N_BTagsM>=3)&&DNNPredictedClass_le5j_ge3t==1)","ljets_le5j_ge3t_ttb_bb_node",""),
-        ("((N_Jets<=5&&N_BTagsM>=3)&&DNNPredictedClass_le5j_ge3t==2)","ljets_le5j_ge3t_tt2b_node",""),
-        ("((N_Jets<=5&&N_BTagsM>=3)&&DNNPredictedClass_le5j_ge3t==3)","ljets_le5j_ge3t_ttcc_node",""),
-        ("((N_Jets<=5&&N_BTagsM>=3)&&DNNPredictedClass_le5j_ge3t==4)","ljets_le5j_ge3t_ttlf_node",""),
-        ]
-    discrs += [
-        "DNNOutput_le5j_ge3t_node_ttH",
-        "DNNOutput_le5j_ge3t_node_ttb_bb",
-        "DNNOutput_le5j_ge3t_node_tt2b",
-        "DNNOutput_le5j_ge3t_node_ttcc",
-        "DNNOutput_le5j_ge3t_node_ttlf",
-        ]
-    nhistobins += [ndefaultbins, ndefaultbins, ndefaultbins, ndefaultbins, ndefaultbins]
-    minxvals += [0.2, 0.2, 0.2, 0.2, 0.2]
-    maxxvals += [0.91, 0.66, 0.71, 0.42, 0.6]
 
-
-
+    category_dict["category"] = ("((N_Jets<=5&&N_BTagsM>=3)&&DNNPredictedClass_le5j_ge3t==0)","ljets_le5j_ge3t_ttH_node","")
+    category_dict["discr"] = "DNNOutput_le5j_ge3t_node_ttH"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1746,
+				0.2254,
+				0.2761,
+				0.3268,
+				0.3775,
+				0.4282,
+				0.4789,
+				0.5296,
+				0.5804,
+				0.6311,
+				0.6818,
+				0.7325,
+				0.7832,
+				0.8339,
+				0.8846,
+				0.91 
+			]
+    this_dict["ljets_le5j_ge3t_ttH_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets<=5&&N_BTagsM>=3)&&DNNPredictedClass_le5j_ge3t==1)","ljets_le5j_ge3t_ttb_bb_node","")
+    category_dict["discr"] = "DNNOutput_le5j_ge3t_node_ttb_bb"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1836,
+				0.2164,
+				0.2493,
+				0.2821,
+				0.315,
+				0.3479,
+				0.3807,
+				0.4136,
+				0.4464,
+				0.4793,
+				0.5121,
+				0.545,
+				0.5779,
+				0.6107,
+				0.6436,
+				0.66 
+			]
+    this_dict["ljets_le5j_ge3t_ttb_bb_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets<=5&&N_BTagsM>=3)&&DNNPredictedClass_le5j_ge3t==2)","ljets_le5j_ge3t_tt2b_node","")
+    category_dict["discr"] = "DNNOutput_le5j_ge3t_node_tt2b"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1818,
+				0.2182,
+				0.2546,
+				0.2911,
+				0.3275,
+				0.3639,
+				0.4004,
+				0.4368,
+				0.4732,
+				0.5096,
+				0.5461,
+				0.5825,
+				0.6189,
+				0.6554,
+				0.6918,
+				0.71 
+			]
+    this_dict["ljets_le5j_ge3t_tt2b_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets<=5&&N_BTagsM>=3)&&DNNPredictedClass_le5j_ge3t==3)","ljets_le5j_ge3t_ttcc_node","")
+    category_dict["discr"] = "DNNOutput_le5j_ge3t_node_ttcc"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1921,
+				0.2079,
+				0.2236,
+				0.2393,
+				0.255,
+				0.2707,
+				0.2864,
+				0.3021,
+				0.3179,
+				0.3336,
+				0.3493,
+				0.365,
+				0.3807,
+				0.3964,
+				0.4121,
+				0.42 
+			]
+    this_dict["ljets_le5j_ge3t_ttcc_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets<=5&&N_BTagsM>=3)&&DNNPredictedClass_le5j_ge3t==4)","ljets_le5j_ge3t_ttlf_node","")
+    category_dict["discr"] = "DNNOutput_le5j_ge3t_node_ttlf"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1857,
+				0.2143,
+				0.2429,
+				0.2714,
+				0.3,
+				0.3286,
+				0.3571,
+				0.3857,
+				0.4143,
+				0.4429,
+				0.4714,
+				0.5,
+				0.5286,
+				0.5571,
+				0.5857,
+				0.6 
+			]
+    this_dict["ljets_le5j_ge3t_ttlf_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
 
 
     # plots for le5j_3t
-    categories += [
-        ("((N_Jets<=5&&N_BTagsM==3)&&DNNPredictedClass_le5j_3t==0)","ljets_le5j_3t_ttH_node",""),
-        ("((N_Jets<=5&&N_BTagsM==3)&&DNNPredictedClass_le5j_3t==1)","ljets_le5j_3t_ttb_bb_node",""),
-        ("((N_Jets<=5&&N_BTagsM==3)&&DNNPredictedClass_le5j_3t==2)","ljets_le5j_3t_tt2b_node",""),
-        ("((N_Jets<=5&&N_BTagsM==3)&&DNNPredictedClass_le5j_3t==3)","ljets_le5j_3t_ttcc_node",""),
-        ("((N_Jets<=5&&N_BTagsM==3)&&DNNPredictedClass_le5j_3t==4)","ljets_le5j_3t_ttlf_node",""),
-        ]
-    discrs += [
-        "DNNOutput_le5j_3t_node_ttH",
-        "DNNOutput_le5j_3t_node_ttb_bb",
-        "DNNOutput_le5j_3t_node_tt2b",
-        "DNNOutput_le5j_3t_node_ttcc",
-        "DNNOutput_le5j_3t_node_ttlf",
-        ]
-    nhistobins += [ndefaultbins, ndefaultbins, ndefaultbins, ndefaultbins, ndefaultbins]
-    minxvals += [0.2, 0.2, 0.2, 0.2, 0.2]
-    maxxvals += [0.88, 0.58, 0.72, 0.42, 0.58]
 
-
-
+    category_dict["category"] = ("((N_Jets<=5&&N_BTagsM==3)&&DNNPredictedClass_le5j_3t==0)","ljets_le5j_3t_ttH_node","")
+    category_dict["discr"] = "DNNOutput_le5j_3t_node_ttH"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1757,
+				0.2243,
+				0.2729,
+				0.3214,
+				0.37,
+				0.4186,
+				0.4671,
+				0.5157,
+				0.5643,
+				0.6129,
+				0.6614,
+				0.71,
+				0.7586,
+				0.8071,
+				0.8557,
+				0.88 
+			]
+    this_dict["ljets_le5j_3t_ttH_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets<=5&&N_BTagsM==3)&&DNNPredictedClass_le5j_3t==1)","ljets_le5j_3t_ttb_bb_node","")
+    category_dict["discr"] = "DNNOutput_le5j_3t_node_ttb_bb"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1864,
+				0.2136,
+				0.2407,
+				0.2679,
+				0.295,
+				0.3221,
+				0.3493,
+				0.3764,
+				0.4036,
+				0.4307,
+				0.4579,
+				0.485,
+				0.5121,
+				0.5393,
+				0.5664,
+				0.58 
+			]
+    this_dict["ljets_le5j_3t_ttb_bb_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets<=5&&N_BTagsM==3)&&DNNPredictedClass_le5j_3t==2)","ljets_le5j_3t_tt2b_node","")
+    category_dict["discr"] = "DNNOutput_le5j_3t_node_tt2b"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1814,
+				0.2186,
+				0.2557,
+				0.2929,
+				0.33,
+				0.3671,
+				0.4043,
+				0.4414,
+				0.4786,
+				0.5157,
+				0.5529,
+				0.59,
+				0.6271,
+				0.6643,
+				0.7014,
+				0.72 
+			]
+    this_dict["ljets_le5j_3t_tt2b_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets<=5&&N_BTagsM==3)&&DNNPredictedClass_le5j_3t==3)","ljets_le5j_3t_ttcc_node","")
+    category_dict["discr"] = "DNNOutput_le5j_3t_node_ttcc"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1921,
+				0.2079,
+				0.2236,
+				0.2393,
+				0.255,
+				0.2707,
+				0.2864,
+				0.3021,
+				0.3179,
+				0.3336,
+				0.3493,
+				0.365,
+				0.3807,
+				0.3964,
+				0.4121,
+				0.42 
+			]
+    this_dict["ljets_le5j_3t_ttcc_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets<=5&&N_BTagsM==3)&&DNNPredictedClass_le5j_3t==4)","ljets_le5j_3t_ttlf_node","")
+    category_dict["discr"] = "DNNOutput_le5j_3t_node_ttlf"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1864,
+				0.2136,
+				0.2407,
+				0.2679,
+				0.295,
+				0.3221,
+				0.3493,
+				0.3764,
+				0.4036,
+				0.4307,
+				0.4579,
+				0.485,
+				0.5121,
+				0.5393,
+				0.5664,
+				0.58 
+			]
+    this_dict["ljets_le5j_3t_ttlf_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
 
 
     # plots for le5j_ge4t
-    categories += [
-        ("((N_Jets<=5&&N_BTagsM>=4)&&DNNPredictedClass_le5j_ge4t==0)","ljets_le5j_ge4t_ttH_node",""),
-        ("((N_Jets<=5&&N_BTagsM>=4)&&DNNPredictedClass_le5j_ge4t==1)","ljets_le5j_ge4t_ttb_bb_node",""),
-        ("((N_Jets<=5&&N_BTagsM>=4)&&DNNPredictedClass_le5j_ge4t==2)","ljets_le5j_ge4t_tt2b_node",""),
-        ("((N_Jets<=5&&N_BTagsM>=4)&&DNNPredictedClass_le5j_ge4t==3)","ljets_le5j_ge4t_ttcc_node",""),
-        ("((N_Jets<=5&&N_BTagsM>=4)&&DNNPredictedClass_le5j_ge4t==4)","ljets_le5j_ge4t_ttlf_node",""),
-        ]
-    discrs += [
-        "DNNOutput_le5j_ge4t_node_ttH",
-        "DNNOutput_le5j_ge4t_node_ttb_bb",
-        "DNNOutput_le5j_ge4t_node_tt2b",
-        "DNNOutput_le5j_ge4t_node_ttcc",
-        "DNNOutput_le5j_ge4t_node_ttlf",
-        ]
-    nhistobins += [ndefaultbins, ndefaultbins, ndefaultbins, ndefaultbins, ndefaultbins]
-    minxvals += [0.2, 0.2, 0.2, 0.2, 0.2]
-    maxxvals += [0.91, 0.61, 0.65, 0.45, 0.55]
 
-
-
+    category_dict["category"] = ("((N_Jets<=5&&N_BTagsM>=4)&&DNNPredictedClass_le5j_ge4t==0)","ljets_le5j_ge4t_ttH_node","")
+    category_dict["discr"] = "DNNOutput_le5j_ge4t_node_ttH"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1746,
+				0.2254,
+				0.2761,
+				0.3268,
+				0.3775,
+				0.4282,
+				0.4789,
+				0.5296,
+				0.5804,
+				0.6311,
+				0.6818,
+				0.7325,
+				0.7832,
+				0.8339,
+				0.8846,
+				0.91 
+			]
+    this_dict["ljets_le5j_ge4t_ttH_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets<=5&&N_BTagsM>=4)&&DNNPredictedClass_le5j_ge4t==1)","ljets_le5j_ge4t_ttb_bb_node","")
+    category_dict["discr"] = "DNNOutput_le5j_ge4t_node_ttb_bb"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1854,
+				0.2146,
+				0.2439,
+				0.2732,
+				0.3025,
+				0.3318,
+				0.3611,
+				0.3904,
+				0.4196,
+				0.4489,
+				0.4782,
+				0.5075,
+				0.5368,
+				0.5661,
+				0.5954,
+				0.61 
+			]
+    this_dict["ljets_le5j_ge4t_ttb_bb_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets<=5&&N_BTagsM>=4)&&DNNPredictedClass_le5j_ge4t==2)","ljets_le5j_ge4t_tt2b_node","")
+    category_dict["discr"] = "DNNOutput_le5j_ge4t_node_tt2b"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1839,
+				0.2161,
+				0.2482,
+				0.2804,
+				0.3125,
+				0.3446,
+				0.3768,
+				0.4089,
+				0.4411,
+				0.4732,
+				0.5054,
+				0.5375,
+				0.5696,
+				0.6018,
+				0.6339,
+				0.65 
+			]
+    this_dict["ljets_le5j_ge4t_tt2b_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets<=5&&N_BTagsM>=4)&&DNNPredictedClass_le5j_ge4t==3)","ljets_le5j_ge4t_ttcc_node","")
+    category_dict["discr"] = "DNNOutput_le5j_ge4t_node_ttcc"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1911,
+				0.2089,
+				0.2268,
+				0.2446,
+				0.2625,
+				0.2804,
+				0.2982,
+				0.3161,
+				0.3339,
+				0.3518,
+				0.3696,
+				0.3875,
+				0.4054,
+				0.4232,
+				0.4411,
+				0.45 
+			]
+    this_dict["ljets_le5j_ge4t_ttcc_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets<=5&&N_BTagsM>=4)&&DNNPredictedClass_le5j_ge4t==4)","ljets_le5j_ge4t_ttlf_node","")
+    category_dict["discr"] = "DNNOutput_le5j_ge4t_node_ttlf"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1875,
+				0.2125,
+				0.2375,
+				0.2625,
+				0.2875,
+				0.3125,
+				0.3375,
+				0.3625,
+				0.3875,
+				0.4125,
+				0.4375,
+				0.4625,
+				0.4875,
+				0.5125,
+				0.5375,
+				0.55 
+			]
+    this_dict["ljets_le5j_ge4t_ttlf_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
 
 
     # plots for ge4j_ge4t
-    categories += [
-        ("((N_Jets>=4&&N_BTagsM>=4)&&DNNPredictedClass_ge4j_ge4t==0)","ljets_ge4j_ge4t_ttH_node",""),
-        ("((N_Jets>=4&&N_BTagsM>=4)&&DNNPredictedClass_ge4j_ge4t==1)","ljets_ge4j_ge4t_ttb_bb_node",""),
-        ("((N_Jets>=4&&N_BTagsM>=4)&&DNNPredictedClass_ge4j_ge4t==2)","ljets_ge4j_ge4t_tt2b_node",""),
-        ("((N_Jets>=4&&N_BTagsM>=4)&&DNNPredictedClass_ge4j_ge4t==3)","ljets_ge4j_ge4t_ttcc_node",""),
-        ("((N_Jets>=4&&N_BTagsM>=4)&&DNNPredictedClass_ge4j_ge4t==4)","ljets_ge4j_ge4t_ttlf_node",""),
-        ]
-    discrs += [
-        "DNNOutput_ge4j_ge4t_node_ttH",
-        "DNNOutput_ge4j_ge4t_node_ttb_bb",
-        "DNNOutput_ge4j_ge4t_node_tt2b",
-        "DNNOutput_ge4j_ge4t_node_ttcc",
-        "DNNOutput_ge4j_ge4t_node_ttlf",
-        ]
-    nhistobins += [ndefaultbins, ndefaultbins, ndefaultbins, ndefaultbins, ndefaultbins]
-    minxvals += [0.2, 0.2, 0.2, 0.2, 0.2]
-    maxxvals += [0.86, 0.67, 0.54, 0.46, 0.64]
 
-
-
+    category_dict["category"] = ("((N_Jets>=4&&N_BTagsM>=4)&&DNNPredictedClass_ge4j_ge4t==0)","ljets_ge4j_ge4t_ttH_node","")
+    category_dict["discr"] = "DNNOutput_ge4j_ge4t_node_ttH"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1764,
+				0.2236,
+				0.2707,
+				0.3179,
+				0.365,
+				0.4121,
+				0.4593,
+				0.5064,
+				0.5536,
+				0.6007,
+				0.6479,
+				0.695,
+				0.7421,
+				0.7893,
+				0.8364,
+				0.86 
+			]
+    this_dict["ljets_ge4j_ge4t_ttH_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets>=4&&N_BTagsM>=4)&&DNNPredictedClass_ge4j_ge4t==1)","ljets_ge4j_ge4t_ttb_bb_node","")
+    category_dict["discr"] = "DNNOutput_ge4j_ge4t_node_ttb_bb"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1832,
+				0.2168,
+				0.2504,
+				0.2839,
+				0.3175,
+				0.3511,
+				0.3846,
+				0.4182,
+				0.4518,
+				0.4854,
+				0.5189,
+				0.5525,
+				0.5861,
+				0.6196,
+				0.6532,
+				0.67 
+			]
+    this_dict["ljets_ge4j_ge4t_ttb_bb_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets>=4&&N_BTagsM>=4)&&DNNPredictedClass_ge4j_ge4t==2)","ljets_ge4j_ge4t_tt2b_node","")
+    category_dict["discr"] = "DNNOutput_ge4j_ge4t_node_tt2b"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1879,
+				0.2121,
+				0.2364,
+				0.2607,
+				0.285,
+				0.3093,
+				0.3336,
+				0.3579,
+				0.3821,
+				0.4064,
+				0.4307,
+				0.455,
+				0.4793,
+				0.5036,
+				0.5279,
+				0.54 
+			]
+    this_dict["ljets_ge4j_ge4t_tt2b_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets>=4&&N_BTagsM>=4)&&DNNPredictedClass_ge4j_ge4t==3)","ljets_ge4j_ge4t_ttcc_node","")
+    category_dict["discr"] = "DNNOutput_ge4j_ge4t_node_ttcc"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1907,
+				0.2093,
+				0.2279,
+				0.2464,
+				0.265,
+				0.2836,
+				0.3021,
+				0.3207,
+				0.3393,
+				0.3579,
+				0.3764,
+				0.395,
+				0.4136,
+				0.4321,
+				0.4507,
+				0.46 
+			]
+    this_dict["ljets_ge4j_ge4t_ttcc_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets>=4&&N_BTagsM>=4)&&DNNPredictedClass_ge4j_ge4t==4)","ljets_ge4j_ge4t_ttlf_node","")
+    category_dict["discr"] = "DNNOutput_ge4j_ge4t_node_ttlf"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1843,
+				0.2157,
+				0.2471,
+				0.2786,
+				0.31,
+				0.3414,
+				0.3729,
+				0.4043,
+				0.4357,
+				0.4671,
+				0.4986,
+				0.53,
+				0.5614,
+				0.5929,
+				0.6243,
+				0.64 
+			]
+    this_dict["ljets_ge4j_ge4t_ttlf_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
 
 
     # plots for ge4j_ge3t
-    categories += [
-        ("((N_Jets>=4&&N_BTagsM>=3)&&DNNPredictedClass_ge4j_ge3t==0)","ljets_ge4j_ge3t_ttH_node",""),
-        ("((N_Jets>=4&&N_BTagsM>=3)&&DNNPredictedClass_ge4j_ge3t==1)","ljets_ge4j_ge3t_ttb_bb_node",""),
-        ("((N_Jets>=4&&N_BTagsM>=3)&&DNNPredictedClass_ge4j_ge3t==2)","ljets_ge4j_ge3t_tt2b_node",""),
-        ("((N_Jets>=4&&N_BTagsM>=3)&&DNNPredictedClass_ge4j_ge3t==3)","ljets_ge4j_ge3t_ttcc_node",""),
-        ("((N_Jets>=4&&N_BTagsM>=3)&&DNNPredictedClass_ge4j_ge3t==4)","ljets_ge4j_ge3t_ttlf_node",""),
-        ]
-    discrs += [
-        "DNNOutput_ge4j_ge3t_node_ttH",
-        "DNNOutput_ge4j_ge3t_node_ttb_bb",
-        "DNNOutput_ge4j_ge3t_node_tt2b",
-        "DNNOutput_ge4j_ge3t_node_ttcc",
-        "DNNOutput_ge4j_ge3t_node_ttlf",
-        ]
-    nhistobins += [ndefaultbins, ndefaultbins, ndefaultbins, ndefaultbins, ndefaultbins]
-    minxvals += [0.2, 0.2, 0.2, 0.2, 0.2]
-    maxxvals += [0.89, 0.74, 0.91, 0.45, 0.67]
 
-
-
-    plotPreselections = [c[0] for c in categories]
-    binlabels =         [c[1] for c in categories]
-
-    DNNPlots = []
-    for discr, sel, label, nbins, minx, maxx in zip(discrs,plotPreselections,binlabels,nhistobins,minxvals,maxxvals):
-        DNNPlots.append(
-            plotClasses.Plot(
-                ROOT.TH1F(discrname+"_"+label,"final discriminator ("+label+")",nbins,minx,maxx),
-                discr,sel,label))
-
-    data.categories += categories
-    data.discrs     += discrs
-    data.nhistobins += nhistobins
-    data.minxvals   += minxvals
-    data.maxxvals   += maxxvals
+    category_dict["category"] = ("((N_Jets>=4&&N_BTagsM>=3)&&DNNPredictedClass_ge4j_ge3t==0)","ljets_ge4j_ge3t_ttH_node","")
+    category_dict["discr"] = "DNNOutput_ge4j_ge3t_node_ttH"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1754,
+				0.2246,
+				0.2739,
+				0.3232,
+				0.3725,
+				0.4218,
+				0.4711,
+				0.5204,
+				0.5696,
+				0.6189,
+				0.6682,
+				0.7175,
+				0.7668,
+				0.8161,
+				0.8654,
+				0.89 
+			]
+    this_dict["ljets_ge4j_ge3t_ttH_node"] = deepcopy(category_dict)
+    category_dict.clear()
     
-    data.plotPreselections  += plotPreselections
-    data.binlabels          += binlabels
+    category_dict["category"] = ("((N_Jets>=4&&N_BTagsM>=3)&&DNNPredictedClass_ge4j_ge3t==1)","ljets_ge4j_ge3t_ttb_bb_node","")
+    category_dict["discr"] = "DNNOutput_ge4j_ge3t_node_ttb_bb"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1807,
+				0.2193,
+				0.2579,
+				0.2964,
+				0.335,
+				0.3736,
+				0.4121,
+				0.4507,
+				0.4893,
+				0.5279,
+				0.5664,
+				0.605,
+				0.6436,
+				0.6821,
+				0.7207,
+				0.74 
+			]
+    this_dict["ljets_ge4j_ge3t_ttb_bb_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets>=4&&N_BTagsM>=3)&&DNNPredictedClass_ge4j_ge3t==2)","ljets_ge4j_ge3t_tt2b_node","")
+    category_dict["discr"] = "DNNOutput_ge4j_ge3t_node_tt2b"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1746,
+				0.2254,
+				0.2761,
+				0.3268,
+				0.3775,
+				0.4282,
+				0.4789,
+				0.5296,
+				0.5804,
+				0.6311,
+				0.6818,
+				0.7325,
+				0.7832,
+				0.8339,
+				0.8846,
+				0.91 
+			]
+    this_dict["ljets_ge4j_ge3t_tt2b_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets>=4&&N_BTagsM>=3)&&DNNPredictedClass_ge4j_ge3t==3)","ljets_ge4j_ge3t_ttcc_node","")
+    category_dict["discr"] = "DNNOutput_ge4j_ge3t_node_ttcc"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1911,
+				0.2089,
+				0.2268,
+				0.2446,
+				0.2625,
+				0.2804,
+				0.2982,
+				0.3161,
+				0.3339,
+				0.3518,
+				0.3696,
+				0.3875,
+				0.4054,
+				0.4232,
+				0.4411,
+				0.45 
+			]
+    this_dict["ljets_ge4j_ge3t_ttcc_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
+    category_dict["category"] = ("((N_Jets>=4&&N_BTagsM>=3)&&DNNPredictedClass_ge4j_ge3t==4)","ljets_ge4j_ge3t_ttlf_node","")
+    category_dict["discr"] = "DNNOutput_ge4j_ge3t_node_ttlf"
+    category_dict["nhistobins"] = ndefaultbins
+    category_dict["bin_edges"] = [ 0.1832,
+				0.2168,
+				0.2504,
+				0.2839,
+				0.3175,
+				0.3511,
+				0.3846,
+				0.4182,
+				0.4518,
+				0.4854,
+				0.5189,
+				0.5525,
+				0.5861,
+				0.6196,
+				0.6532,
+				0.67 
+			]
+    this_dict["ljets_ge4j_ge3t_ttlf_node"] = deepcopy(category_dict)
+    category_dict.clear()
+    
 
+    for l in this_dict:
+        this_dict[l]["histoname"] = this_dict[l]["discr"]+"_"+l
+        this_dict[l]["histotitle"] = "final discriminator ({})".format(l)
+        this_dict[l]["plotPreselections"] = this_dict[l]["category"][0]
+
+    DNNPlots = init_plots(dictionary = this_dict, data = data)
     return DNNPlots
 
 
@@ -432,3 +995,38 @@ def getDiscriminatorPlots(data = None, discrname = None):
     discriminatorPlots += plots_dnn(data, discrname)
 
     return discriminatorPlots
+
+
+def init_plots(dictionary, data = None):
+    plots = [] #init list of plotClasses objects to return
+    for label in dictionary:
+        subdict = dictionary[label] #for easy access
+        discr = subdict["discr"] # load discriminator name
+        sel = subdict["plotPreselections"] # load selection
+        histoname = subdict["histoname"] # load histogram name
+        histotitle = subdict["histotitle"] # load histogram title
+
+        # check if initialization uses bin edges or min/max vals
+        # if 'subdict' contains the keyword 'bin_edges', an array
+        # of type float is created from the corresponding python list.
+        # Else, the min/maxvals are used 
+        if "bin_edges" in subdict:
+            bins = array("f", subdict["bin_edges"])
+            nbins = len(bins)-1 # last bin edge in array is overflow bin => subtract for nbins
+            subdict["nhistobins"] = nbins # update number of bins
+            plots.append(
+                plotClasses.Plot(
+                    ROOT.TH1F(histoname,histotitle,nbins,bins),
+                    discr,sel,label))
+        elif "minxval" in subdict and "maxxval" in subdict:
+            nbins = subdict["nhistobins"]
+            xmax  = subdict["maxxval"]
+            xmin  = subdict["minxval"]
+            plots.append(
+                plotClasses.Plot(
+                    ROOT.TH1F(histoname, histotitle,nbins,xmin, xmax),
+                    discr,sel,label))
+    if not data is None:
+        data.categories.update(dictionary)
+    return plots
+    

--- a/util/configClass.py
+++ b/util/configClass.py
@@ -11,27 +11,30 @@ import Systematics
 
 class catData:
     def __init__(self):
-        self.discrs = []
-        self.nhistobins = []
-        self.minxvals = []
-        self.maxxvals = []
-        self.categories = []
+        self.categories = {}
 
-        self.plotPreselections = []
-        self.binlabels = []
+        # self.discrs = []
+        # self.nhistobins = []
+        # self.minxvals = []
+        # self.maxxvals = []
+        # self.categories = []
+
+        # self.plotPreselections = []
+        # self.binlabels = []
 
     def getNEntries(self):
-        return len(self.discrs)
+        return len(self.categories)
 
-    def getEntry(self, i):
-        return {
-            "discr":            self.discrs[i],
-            "nhistobins":       self.nhistobins[i],
-            "minxvals":         self.minxvals[i],
-            "maxxvals":         self.maxxvals[i],
-            "category":         self.categories[i],
-            "plotPreselection": self.plotPreselections[i],
-            "binlabel":         self.binlabels[i]}
+    # def getEntry(self, i):
+    #     return {
+    #         "discr":            self.discrs[i],
+    #         "nhistobins":       self.nhistobins[i],
+    #         "minxvals":         self.minxvals[i],
+    #         "maxxvals":         self.maxxvals[i],
+    #         "category":         self.categories[i],
+    #         "plotPreselection": self.plotPreselections[i],
+    #         "binlabel":         self.binlabels[i]}
+
 
 class configData:
     def __init__(self, analysisClass, variable_config, plot_config, execute_file = None):
@@ -78,22 +81,24 @@ class configData:
         self.plots=self.systematics.plot_shapes()
 
     def writeConfigDataToWorkdir(self):
-        if self.Data == None:
-            print("there is no config data")
-            return
+        # if self.Data == None:
+        #     print("there is no config data")
+        #     return
 
-        with open(self.analysis.workdir+"/configData.csv", "w") as csvf:
-            csvf.write("categories,nhistobins,minxvals,maxxvals,discrs")
-            for i in range(len(self.Data.categories)):
-                line = "\n"
-                line+= str(self.Data.categories[i])+";"
-                line+= str(self.Data.nhistobins[i])+";"
-                line+= str(self.Data.minxvals[i])+";"
-                line+= str(self.Data.maxxvals[i])+";"
-                line+= str(self.Data.discrs[i])
-                csvf.write(line)
-        print("wrote config data to workdir")
-        print("path: "+str(self.analysis.workdir+"/configData.csv"))
+        # with open(self.analysis.workdir+"/configData.csv", "w") as csvf:
+        #     csvf.write("categories,nhistobins,minxvals,maxxvals,discrs")
+        #     for label in self.Data.categories:
+        #         subdict = self.Data.categories[label]
+        #         line = "\n"
+        #         line+= str(subdict["categories"])+";"
+        #         line+= str(subdict["nhistobins"])+";"
+        #         if "bin_edges" in 
+        #         line+= str(self.Data.minxvals[i])+";"
+        #         line+= str(self.Data.maxxvals[i])+";"
+        #         line+= str(self.Data.discrs[i])
+        #         csvf.write(line)
+        # print("wrote config data to workdir")
+        # print("path: "+str(self.analysis.workdir+"/configData.csv"))
         return
 
     def genDiscriminatorPlots(self, memexp, dnnInterface = None):
@@ -142,7 +147,7 @@ class configData:
             return self.discriminatorPlots
 
     def getBinlabels(self):
-        return self.Data.binlabels
+        return self.Data.categories.keys()
 
     def getAddVariables(self):
         sys.path.append(self.cfgdir)

--- a/util/scriptFiles/plotHead.cc
+++ b/util/scriptFiles/plotHead.cc
@@ -32,11 +32,9 @@ struct Plot2DInfoStruct{
     std::string identifier;
     std::string title;
     int nbinsx;
+    std::vector<float> edges_x;
     int nbinsy;
-    float xmin;
-    float xmax;
-    float ymin;
-    float ymax;
+    std::vector<float> edges_y;
     //std::unique_ptr<TH2> histoptr;
 };
 

--- a/util/scriptFiles/plotHead.cc
+++ b/util/scriptFiles/plotHead.cc
@@ -3,8 +3,7 @@ struct Plot1DInfoStruct{
     std::string identifier;
     std::string title;
     int nbins;
-    double xmin;
-    double xmax;
+    std::vector<float> edges;
     //std::unique_ptr<TH1> histoptr;
 };
 

--- a/util/tools/plotClasses.py
+++ b/util/tools/plotClasses.py
@@ -99,7 +99,7 @@ class Sample:
 
 
 class Plot:
-    def __init__(self, histo, variable = '', selection = '',label = ''):
+    def __init__(self, histo, variable = '', selection = '',label = '', variable_bin_width = False):
         if isinstance(histo,ROOT.TH1):
             self.histo = histo
             self.name = histo.GetName()
@@ -113,6 +113,7 @@ class Plot:
         self.selection = selection
         self.label = label
         self.dim = 1
+        self.variable_bin_width = variable_bin_width
 
 class TwoDimPlot:
     def __init__(self, histo, variable1 = '', variable2 = '', selection = '',label = ''):

--- a/util/tools/scriptfunctions.py
+++ b/util/tools/scriptfunctions.py
@@ -118,10 +118,11 @@ def initHistos(catnames, systnames, plots):
         else:
             title  = plot.histo.GetTitle()
             name   = plot.histo.GetName()
-            maxX   = plot.histo.GetXaxis().GetXmax()
-            minX   = plot.histo.GetXaxis().GetXmin()
             nbins  = plot.histo.GetNbinsX()
-            rstr  += "plotinfo1D[\""+name+"\"] = {\""+name+"\",\""+title+"\","+str(nbins)+","+str(minX)+","+str(maxX)+"};\n"
+            bin_edges = []
+            for i in range(1, nbins+2):
+              bin_edges.append(str(plot.histo.GetBinLowEdge(i)))
+            rstr  += """plotinfo1D["{0}"] = {{"{0}","{1}",{2},{{ {3} }} }};\n""".format(name, title, nbins, ",".join(bin_edges))
 
     rstr += "\n\n"
     rstr += "for(const auto& cat: categs){\n"
@@ -129,7 +130,7 @@ def initHistos(catnames, systnames, plots):
     rstr += "        for(const auto& syst: systematics){\n"
     rstr += "            const auto& PlotInfo1D = obj.second;\n"
     rstr += "            histos1D[cat+obj.first+syst] = "
-    rstr += "std::unique_ptr<TH1>(new TH1F((processname+\"_\"+cat+obj.first+syst+suffix).c_str(), (PlotInfo1D.title).c_str(), PlotInfo1D.nbins, PlotInfo1D.xmin, PlotInfo1D.xmax));\n"
+    rstr += "std::unique_ptr<TH1>(new TH1F((processname+\"_\"+cat+obj.first+syst+suffix).c_str(), (PlotInfo1D.title).c_str(), PlotInfo1D.nbins, PlotInfo1D.edges.data()));\n"
     rstr += "            histos1D[cat+obj.first+syst]->SetDirectory(0);\n"
     rstr += "        }\n"
     rstr += "    }\n"

--- a/util/tools/scriptfunctions.py
+++ b/util/tools/scriptfunctions.py
@@ -108,13 +108,15 @@ def initHistos(catnames, systnames, plots):
         if isinstance(plot, plotClasses.TwoDimPlot):
             title  = plot.histo.GetTitle()+";"+plot.histo.GetXaxis().GetTitle()+";"+plot.histo.GetYaxis().GetTitle()
             name   = plot.histo.GetName()
-            maxX   = plot.histo.GetXaxis().GetXmax()
-            minX   = plot.histo.GetXaxis().GetXmin()
             nbinsX = plot.histo.GetNbinsX()
-            maxY   = plot.histo.GetYaxis().GetXmax()
-            minY   = plot.histo.GetYaxis().GetXmin()
+            bin_edges_x = []
+            for i in range(1, nbins+2):
+              bin_edges.append(str(plot.histo.GetXaxis().GetBinLowEdge(i)))
             nbinsY = plot.histo.GetNbinsY()
-            rstr  += "plotinfo2D[\""+name+"\"] = {\""+name+"\",\""+title+"\","+str(nbinsX)+","+str(minX)+","+str(maxX)+","+str(minY)+","+str(maxY)+"};\n"
+            bin_edges_y = []
+            for i in range(1, nbins+2):
+              bin_edges_y.append(str(plot.histo.GetYaxis().GetBinLowEdge(i)))
+            rstr  += """plotinfo2D["{0}"] = {{"{0}","{1}",{2},{{ {3} }}, {4}, {{ {5} }} }};\n""".format(name, title, nbinsX, ",".join(bin_edges_x), nbinsY, ",".join(bin_edges_y))
         else:
             title  = plot.histo.GetTitle()
             name   = plot.histo.GetName()
@@ -142,7 +144,7 @@ def initHistos(catnames, systnames, plots):
     rstr += "            const auto& PlotInfo2D = obj.second;\n"
     rstr += "            histos2D[cat+obj.first+syst] = "
     rstr += "std::unique_ptr<TH2>(new TH2F((processname+\"_\"+cat+obj.first+syst+suffix).c_str(), (PlotInfo2D.title).c_str(), "
-    rstr += "PlotInfo2D.nbinsx, PlotInfo2D.xmin, PlotInfo2D.xmax, PlotInfo2D.nbinsy, PlotInfo2D.ymin, PlotInfo2D.ymax));\n"
+    rstr += "PlotInfo2D.nbinsx, PlotInfo2D.edges_x.data(), PlotInfo2D.nbinsy, PlotInfo2D.edges_y.data()));\n"
     rstr += "            histos2D[cat+obj.first+syst]->SetDirectory(0);\n"
     rstr += "        }\n"
     rstr += "    }\n"

--- a/util/tools/scriptfunctions.py
+++ b/util/tools/scriptfunctions.py
@@ -87,7 +87,7 @@ def InitDataBase(thisDataBase=[]):
 
 
 # -- initializing histograms ----------------------------------------------------------------------
-def initHistos(catnames, systnames, plots):
+def initHistos(catnames, systnames, plots, edge_precision=4):
     rstr = ""
     rstr += "double variable = -999;\n"
     rstr += "double variable1 = -999;\n"
@@ -111,19 +111,22 @@ def initHistos(catnames, systnames, plots):
             nbinsX = plot.histo.GetNbinsX()
             bin_edges_x = []
             for i in range(1, nbins+2):
-              bin_edges.append(str(plot.histo.GetXaxis().GetBinLowEdge(i)))
+              bin_edges.append(str(round(plot.histo.GetXaxis().GetBinLowEdge(i),edge_precision)))
             nbinsY = plot.histo.GetNbinsY()
             bin_edges_y = []
             for i in range(1, nbins+2):
-              bin_edges_y.append(str(plot.histo.GetYaxis().GetBinLowEdge(i)))
-            rstr  += """plotinfo2D["{0}"] = {{"{0}","{1}",{2},{{ {3} }}, {4}, {{ {5} }} }};\n""".format(name, title, nbinsX, ",".join(bin_edges_x), nbinsY, ",".join(bin_edges_y))
+              bin_edges_y.append(str(round(plot.histo.GetYaxis().GetBinLowEdge(i),edge_precision)))
+            rstr  += """plotinfo2D["{0}"] = {{"{0}","{1}",{2},{{ {3} }}, {4}, {{ {5} }} }};\n""".format(name, title, 
+                                                                                                        nbinsX, ",".join(bin_edges_x), 
+                                                                                                        nbinsY, ",".join(bin_edges_y)
+                                                                                                        )
         else:
             title  = plot.histo.GetTitle()
             name   = plot.histo.GetName()
             nbins  = plot.histo.GetNbinsX()
             bin_edges = []
             for i in range(1, nbins+2):
-              bin_edges.append(str(plot.histo.GetBinLowEdge(i)))
+              bin_edges.append(str(round(plot.histo.GetBinLowEdge(i),edge_precision)))
             rstr  += """plotinfo1D["{0}"] = {{"{0}","{1}",{2},{{ {3} }} }};\n""".format(name, title, nbins, ",".join(bin_edges))
 
     rstr += "\n\n"


### PR DESCRIPTION
implemented variable binnning:
- changed c++ code to use low bin edges for TH1/2 init
- changed catData class to use a nested dictionary instead of different lists
  - top level key: node label (e.g. `ljets_ge4j_ge3t_ttH_node`)
  - dictionary `catData.categories[label]` contains information about the histogram, e.g.
    - preselection
    - discriminator name
    - number of bins
    - xmin/xmax or bin edges
    - ...
  - CAREFUL: This means that this new catData class IS NOT backwards compatible with older configs!
- changed `util/dNNInterfaces/MLfoyInterface.py` to enable variable binning and implemented new dictionary-based structure
  - if variable binning is activated, a default list of bin edges corresponding to an equal binning is generated
  - the dictionary is filled with the required information (currently only for discriminator output plots)
  - the initialization of histograms from this config is done in a dedicated function  