### PR TITLE
The real legacy analysis necessary systs only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ workdir/*
 *.sub
 *.err
 *.csv
+*.pickle

--- a/util/configClass.py
+++ b/util/configClass.py
@@ -48,12 +48,12 @@ class configData:
     def initData(self):
         self.Data = catData()
 
-    def getData():
+    def getData(self):
         return self.Data
 
     def initSystematics(self,systconfig):
 
-        print "loading systematics..."
+        print( "loading systematics...")
         self.systconfig=systconfig
         processes=self.pltcfg.list_of_processes
         workdir=self.analysis.workdir

--- a/util/scriptFiles/interface/BaseHistoHelper.h
+++ b/util/scriptFiles/interface/BaseHistoHelper.h
@@ -1,0 +1,63 @@
+#if !defined(BASEHISTOHELPERH)
+#define BASEHISTOHELPERH
+
+#include "TH1.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include <map>
+#include <vector>
+#include <string>
+
+
+class BaseHistoHelper{
+    public:
+        // Helper struct to fill plots more efficiently
+        // Until GCC 4.9 struct cannot have init values if one wants to initialize it with bracket lists
+        struct structHelpFillHisto{
+            TH1* histo;
+            double weight;
+        };
+        struct structHelpFillTwoDimHisto{
+            TH2* histo;
+            double weight;
+        };
+
+        BaseHistoHelper() {}
+        
+        virtual ~BaseHistoHelper() {}
+
+        void push_back(std::string plotname, std::shared_ptr<TH1> histo){
+            histo_map[plotname] = histo;
+            histo_map[plotname]->SetDirectory(0);
+        }
+        
+        std::vector<std::string>& GetSystematics(){return systematics;}
+        void SetSystematics( std::vector<std::string>& input) {
+            systematics = input;
+        }
+        std::string& GetCurrentVariation(){return variation;}
+        void SetCurrentVariation( std::string& input) {
+            variation = input;
+        }
+        bool& GetSkipWeightSysts(){return skipWeightSysts;}
+        void SetSkipWeightSysts( bool& input) {
+            skipWeightSysts = input;
+        }
+        std::map<std::string, std::shared_ptr<TH1>>& GetHistoMap(){return histo_map;}
+        void SetHistoMap(std::map<std::string, std::shared_ptr<TH1>>& input) {
+            histo_map = input;
+            std::cout << "set map with following entries:" << std::endl;
+            for(auto entry: histo_map){
+                std::cout << "\t" << entry.first << std::endl;
+            }
+        }
+    protected:
+        std::vector<std::string> systematics;
+        std::map<std::string, std::shared_ptr<TH1>> histo_map;
+        std::string variation;
+        bool skipWeightSysts;
+};
+
+
+
+#endif // BASEHISTOHELPERH

--- a/util/scriptFiles/interface/BaseHistoHelper.h
+++ b/util/scriptFiles/interface/BaseHistoHelper.h
@@ -9,12 +9,12 @@
 #include <string>
 
 
-class BaseHistoHelper{
+template<class T> class BaseHistoHelper{
     public:
         // Helper struct to fill plots more efficiently
         // Until GCC 4.9 struct cannot have init values if one wants to initialize it with bracket lists
         struct structHelpFillHisto{
-            TH1* histo;
+            T* histo;
             double weight;
         };
         struct structHelpFillTwoDimHisto{
@@ -22,11 +22,23 @@ class BaseHistoHelper{
             double weight;
         };
 
-        BaseHistoHelper() {}
+        BaseHistoHelper(){
+            std::cout << "initialized empty BaseHistoHelper!" << std::endl;
+        }
+
+        BaseHistoHelper(std::map<std::string, std::shared_ptr<T>> input_map):
+        histo_map(input_map) {}
+
+        BaseHistoHelper(std::string& input_variation, bool& input_skipWeightSysts, 
+                            std::vector<std::string>& input_systematics):
+            variation(input_variation), skipWeightSysts(input_skipWeightSysts),
+            systematics(input_systematics)
+        {  
+        }
         
         virtual ~BaseHistoHelper() {}
 
-        void push_back(std::string plotname, std::shared_ptr<TH1> histo){
+        void push_back(std::string plotname, std::shared_ptr<T> histo){
             histo_map[plotname] = histo;
             histo_map[plotname]->SetDirectory(0);
         }
@@ -43,8 +55,8 @@ class BaseHistoHelper{
         void SetSkipWeightSysts( bool& input) {
             skipWeightSysts = input;
         }
-        std::map<std::string, std::shared_ptr<TH1>>& GetHistoMap(){return histo_map;}
-        void SetHistoMap(std::map<std::string, std::shared_ptr<TH1>>& input) {
+        std::map<std::string, std::shared_ptr<T>>& GetHistoMap(){return histo_map;}
+        void SetHistoMap(std::map<std::string, std::shared_ptr<T>>& input) {
             histo_map = input;
             std::cout << "set map with following entries:" << std::endl;
             for(auto entry: histo_map){
@@ -53,7 +65,7 @@ class BaseHistoHelper{
         }
     protected:
         std::vector<std::string> systematics;
-        std::map<std::string, std::shared_ptr<TH1>> histo_map;
+        std::map<std::string, std::shared_ptr<T>> histo_map;
         std::string variation;
         bool skipWeightSysts;
 };

--- a/util/scriptFiles/interface/OneDimHistoHelper.h
+++ b/util/scriptFiles/interface/OneDimHistoHelper.h
@@ -1,0 +1,35 @@
+#if !defined(ONDEDIMHISTOHELPERH)
+#define ONDEDIMHISTOHELPERH
+
+#include "TH1.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include <map>
+#include <vector>
+#include <string>
+#include "BaseHistoHelper.h"
+
+class OneDimHistoHelper : public BaseHistoHelper{
+    public:
+       
+        OneDimHistoHelper();
+        OneDimHistoHelper(std::map<std::string, std::shared_ptr<TH1>> input_map);
+        OneDimHistoHelper(std::string& input_variation, bool& input_skipWeightSysts, 
+                            std::vector<std::string>& input_systematics) ;
+        ~OneDimHistoHelper();
+
+        void fillNecessaryHistograms (const std::string& plotname,
+                              const float& NomWeight, const float& final_weight,
+                              const std::map<std::string, float>& weight_expressions, 
+                              const float& variable) const;
+        
+        void helperFillHisto(const std::vector<structHelpFillHisto>& paramVec, const double& val) const;
+
+        // BaseHistoHelper::push_back(std::string plotname, std::shared_ptr<TH1> histo);
+    private:
+        
+};
+
+
+
+#endif // ONDEDIMHISTOHELPERH

--- a/util/scriptFiles/interface/OneDimHistoHelper.h
+++ b/util/scriptFiles/interface/OneDimHistoHelper.h
@@ -1,5 +1,5 @@
-#if !defined(ONDEDIMHISTOHELPERH)
-#define ONDEDIMHISTOHELPERH
+#if !defined(ONEDIMHISTOHELPERH)
+#define ONEDIMHISTOHELPERH
 
 #include "TH1.h"
 #include "TH1F.h"
@@ -9,13 +9,9 @@
 #include <string>
 #include "BaseHistoHelper.h"
 
-class OneDimHistoHelper : public BaseHistoHelper{
+class OneDimHistoHelper : public BaseHistoHelper<TH1>{
     public:
        
-        OneDimHistoHelper();
-        OneDimHistoHelper(std::map<std::string, std::shared_ptr<TH1>> input_map);
-        OneDimHistoHelper(std::string& input_variation, bool& input_skipWeightSysts, 
-                            std::vector<std::string>& input_systematics) ;
         ~OneDimHistoHelper();
 
         void fillNecessaryHistograms (const std::string& plotname,
@@ -25,11 +21,10 @@ class OneDimHistoHelper : public BaseHistoHelper{
         
         void helperFillHisto(const std::vector<structHelpFillHisto>& paramVec, const double& val) const;
 
-        // BaseHistoHelper::push_back(std::string plotname, std::shared_ptr<TH1> histo);
     private:
         
 };
 
 
 
-#endif // ONDEDIMHISTOHELPERH
+#endif // ONEDIMHISTOHELPERH

--- a/util/scriptFiles/interface/TwoDimHistoHelper.h
+++ b/util/scriptFiles/interface/TwoDimHistoHelper.h
@@ -1,0 +1,31 @@
+#if !defined(TWODIMHISTOHELPERH)
+#define TWODIMHISTOHELPERH
+
+#include "TH1.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include <map>
+#include <vector>
+#include <string>
+#include "BaseHistoHelper.h"
+
+class TwoDimHistoHelper : public BaseHistoHelper<TH2>{
+    public:
+    //    TwoDimHistoHelper() {}
+        ~TwoDimHistoHelper();
+
+        void fillNecessaryHistograms (const std::string& plotname,
+                              const float& NomWeight, const float& final_weight,
+                              const std::map<std::string, float>& weight_expressions, 
+                              const float& variable1, const float& variable2) const;
+        
+        void helperFillHisto(const std::vector<structHelpFillTwoDimHisto>& paramVec, 
+                                const double& val1, const double& val2) const;
+
+    private:
+        
+};
+
+
+
+#endif // TWODIMHISTOHELPERH

--- a/util/scriptFiles/plotHead.cc
+++ b/util/scriptFiles/plotHead.cc
@@ -7,25 +7,6 @@ struct Plot1DInfoStruct{
     //std::unique_ptr<TH1> histoptr;
 };
 
-
-// Helper struct to fill plots more efficiently
-// Until GCC 4.9 struct cannot have init values if one wants to initialize it with bracket lists
-struct structHelpFillHisto{
-  TH1* histo;
-  double weight;
-};
-
-// helper function to fill plots more efficiently
-void helperFillHisto(const std::vector<structHelpFillHisto>& paramVec, const double& val)
-{
-  for (const auto &singleParams: paramVec)
-  // singleParams: histo, var, weight
-  {
-    if((singleParams.weight)!=0)
-        singleParams.histo->Fill(fmin(singleParams.histo->GetXaxis()->GetXmax()-1e-6,fmax(singleParams.histo->GetXaxis()->GetXmin()+1e-6,val)),singleParams.weight);
-  }
-}
-
 // Helper struct to fill plots more efficiently
 // Until GCC 4.9 struct cannot have init values if one wants to initialize it with bracket lists
 struct Plot2DInfoStruct{
@@ -38,21 +19,7 @@ struct Plot2DInfoStruct{
     //std::unique_ptr<TH2> histoptr;
 };
 
-struct structHelpFillTwoDimHisto{
-  TH2* histo;
-  double weight;
-};
 
-// helper function to fill plots more efficiently
-void helperFillTwoDimHisto(const std::vector<structHelpFillTwoDimHisto>& paramVec, const double& val1, const double& val2)
-{
-  for (const auto &singleParams: paramVec)
-  // singleParams: histo, var1, var2, weight
-  {
-    if((singleParams.weight)!=0)
-        singleParams.histo->Fill(fmin(singleParams.histo->GetXaxis()->GetXmax()-1e-6,fmax(singleParams.histo->GetXaxis()->GetXmin()+1e-6,val1)),fmin(singleParams.histo->GetYaxis()->GetXmax()-1e-6,fmax(singleParams.histo->GetYaxis()->GetXmin()+1e-6,val2)),singleParams.weight);
-  }
-}
 
 void resetMap(std::map<TString, float>& input, const float& val = 1){
   for(auto& entry : input){
@@ -376,6 +343,8 @@ void plot(){
   TStopwatch* timerTotal=new TStopwatch();
   TStopwatch* timerMapping=new TStopwatch();
   
+  // define final weight for event when it's filled into the template
+  float final_weight = 0;
 
  
   // initialize variables from tree

--- a/util/scriptFiles/src/OneDimHistoHelper.cc
+++ b/util/scriptFiles/src/OneDimHistoHelper.cc
@@ -1,20 +1,5 @@
 #include "../interface/OneDimHistoHelper.h"
 
-OneDimHistoHelper::OneDimHistoHelper(){
-    std::cout << "initialized empty OneDimHistoHelper!" << std::endl;
-}
-
-OneDimHistoHelper::OneDimHistoHelper(std::map<std::string, std::shared_ptr<TH1>> input_map)
-{
-  histo_map = input_map;
-}
-OneDimHistoHelper::OneDimHistoHelper(std::string& input_variation, bool& input_skipWeightSysts, 
-                    std::vector<std::string>& input_systematics)
-{
-  variation = input_variation;
-  skipWeightSysts = input_skipWeightSysts;
-  systematics = input_systematics;    
-}
 OneDimHistoHelper::~OneDimHistoHelper(){}
 
 
@@ -23,17 +8,20 @@ void OneDimHistoHelper::fillNecessaryHistograms (const std::string& plotname,
                               const std::map<std::string, float>& weight_expressions, 
                               const float& variable) const
 {
+  /*
+    Basic idea: first collect all relevant templates for plot category 'plotname'.
+    relevant templates are identified by cross referencing the list of all 
+    weight expressions 'weight_expressions' with the current list of
+    relevant systematics 'systematics'.
+
+    After the templates are collected, they are filled in the 'helperFillHisto' function
+  */
   std::vector<structHelpFillHisto> helpWeightVec;
-  std::cout << "current map: " << std::endl;
-  for(auto entry: histo_map){
-        std::cout << "\t" << entry.first << std::endl;
-    }
-  std::cout << "OneDimHistoHelper::fillNecessaryHistograms: fill '" << plotname+variation <<"'" << std::endl;
+  // the nominal template is always relevant, so add it to the list
   helpWeightVec.push_back({histo_map.at(plotname+variation).get(), ((NomWeight)*(final_weight))});
   if (!skipWeightSysts) { // append plots for weight systs if neccessary
     for(auto& systname : systematics){
       if (weight_expressions.find(systname) != weight_expressions.end()){
-          std::cout << "OneDimHistoHelper::fillNecessaryHistograms: fill '" << plotname+systname <<"'" << std::endl;
         helpWeightVec.push_back( { histo_map.at(plotname+systname).get(), 
                                     (weight_expressions.at(systname))*(final_weight) 
                                 } );
@@ -46,6 +34,10 @@ void OneDimHistoHelper::fillNecessaryHistograms (const std::string& plotname,
 // helper function to fill plots more efficiently
 void OneDimHistoHelper::helperFillHisto(const std::vector<structHelpFillHisto>& paramVec, const double& val) const
 {
+  /*
+        Fill templates. First check whether the variable(s) to be filled are not in the under/overflow bin of the template.
+        Then fill while considering the weight
+    */
   for (const auto &singleParams: paramVec)
   // singleParams: histo, var, weight
   {
@@ -53,8 +45,3 @@ void OneDimHistoHelper::helperFillHisto(const std::vector<structHelpFillHisto>& 
         singleParams.histo->Fill(fmin(singleParams.histo->GetXaxis()->GetXmax()-1e-6,fmax(singleParams.histo->GetXaxis()->GetXmin()+1e-6,val)),singleParams.weight);
   }
 }
-
-// void OneDimHistoHelper::push_back(std::string plotname, std::shared_ptr<TH1> histo){
-//     histo_map[plotname] = histo;
-//     histo_map[plotname]->SetDirectory(0);
-// }

--- a/util/scriptFiles/src/OneDimHistoHelper.cc
+++ b/util/scriptFiles/src/OneDimHistoHelper.cc
@@ -1,0 +1,60 @@
+#include "../interface/OneDimHistoHelper.h"
+
+OneDimHistoHelper::OneDimHistoHelper(){
+    std::cout << "initialized empty OneDimHistoHelper!" << std::endl;
+}
+
+OneDimHistoHelper::OneDimHistoHelper(std::map<std::string, std::shared_ptr<TH1>> input_map)
+{
+  histo_map = input_map;
+}
+OneDimHistoHelper::OneDimHistoHelper(std::string& input_variation, bool& input_skipWeightSysts, 
+                    std::vector<std::string>& input_systematics)
+{
+  variation = input_variation;
+  skipWeightSysts = input_skipWeightSysts;
+  systematics = input_systematics;    
+}
+OneDimHistoHelper::~OneDimHistoHelper(){}
+
+
+void OneDimHistoHelper::fillNecessaryHistograms (const std::string& plotname,
+                              const float& NomWeight, const float& final_weight,
+                              const std::map<std::string, float>& weight_expressions, 
+                              const float& variable) const
+{
+  std::vector<structHelpFillHisto> helpWeightVec;
+  std::cout << "current map: " << std::endl;
+  for(auto entry: histo_map){
+        std::cout << "\t" << entry.first << std::endl;
+    }
+  std::cout << "OneDimHistoHelper::fillNecessaryHistograms: fill '" << plotname+variation <<"'" << std::endl;
+  helpWeightVec.push_back({histo_map.at(plotname+variation).get(), ((NomWeight)*(final_weight))});
+  if (!skipWeightSysts) { // append plots for weight systs if neccessary
+    for(auto& systname : systematics){
+      if (weight_expressions.find(systname) != weight_expressions.end()){
+          std::cout << "OneDimHistoHelper::fillNecessaryHistograms: fill '" << plotname+systname <<"'" << std::endl;
+        helpWeightVec.push_back( { histo_map.at(plotname+systname).get(), 
+                                    (weight_expressions.at(systname))*(final_weight) 
+                                } );
+      }
+    } 
+  }
+  this->helperFillHisto(helpWeightVec, variable);
+}
+
+// helper function to fill plots more efficiently
+void OneDimHistoHelper::helperFillHisto(const std::vector<structHelpFillHisto>& paramVec, const double& val) const
+{
+  for (const auto &singleParams: paramVec)
+  // singleParams: histo, var, weight
+  {
+    if((singleParams.weight)!=0)
+        singleParams.histo->Fill(fmin(singleParams.histo->GetXaxis()->GetXmax()-1e-6,fmax(singleParams.histo->GetXaxis()->GetXmin()+1e-6,val)),singleParams.weight);
+  }
+}
+
+// void OneDimHistoHelper::push_back(std::string plotname, std::shared_ptr<TH1> histo){
+//     histo_map[plotname] = histo;
+//     histo_map[plotname]->SetDirectory(0);
+// }

--- a/util/scriptFiles/src/TwoDimHistoHelper.cc
+++ b/util/scriptFiles/src/TwoDimHistoHelper.cc
@@ -1,0 +1,48 @@
+#include "../interface/TwoDimHistoHelper.h"
+
+TwoDimHistoHelper::~TwoDimHistoHelper(){}
+
+void TwoDimHistoHelper::fillNecessaryHistograms (const std::string& plotname,
+                              const float& NomWeight, const float& final_weight,
+                              const std::map<std::string, float>& weight_expressions, 
+                              const float& variable1, const float& variable2) const
+{
+    /*
+    Basic idea: first collect all relevant templates for plot category 'plotname'.
+    relevant templates are identified by cross referencing the list of all 
+    weight expressions 'weight_expressions' with the current list of
+    relevant systematics 'systematics'.
+
+    After the templates are collected, they are filled in the 'helperFillHisto' function
+  */
+  std::vector<structHelpFillTwoDimHisto> helpWeightVec;
+  // the nominal template is always relevant, so add it to the list
+  helpWeightVec.push_back({histo_map.at(plotname+variation).get(), ((NomWeight)*(final_weight))});
+  if (!skipWeightSysts) { // append plots for weight systs if neccessary
+    for(auto& systname : systematics){
+      if (weight_expressions.find(systname) != weight_expressions.end()){
+        helpWeightVec.push_back( { histo_map.at(plotname+systname).get(), 
+                                    (weight_expressions.at(systname))*(final_weight) 
+                                } );
+      }
+    } 
+  }
+  this->helperFillHisto(helpWeightVec, variable1, variable2);
+}
+
+// helper function to fill plots more efficiently
+void TwoDimHistoHelper::helperFillHisto(const std::vector<structHelpFillTwoDimHisto>& paramVec, const double& val1, const double& val2) const
+{
+    /*
+        Fill templates. First check whether the variable(s) to be filled are not in the under/overflow bin of the template.
+        Then fill while considering the weight
+    */
+  for (const auto &singleParams: paramVec)
+  // singleParams: histo, var1, var2, weight
+  {
+    if((singleParams.weight)!=0)
+        singleParams.histo->Fill(fmin(singleParams.histo->GetXaxis()->GetXmax()-1e-6,fmax(singleParams.histo->GetXaxis()->GetXmin()+1e-6,val1)),
+                                fmin(singleParams.histo->GetYaxis()->GetXmax()-1e-6,fmax(singleParams.histo->GetYaxis()->GetXmin()+1e-6,val2))
+                                ,singleParams.weight);
+  }
+}

--- a/util/tools/Systematics.py
+++ b/util/tools/Systematics.py
@@ -58,6 +58,21 @@ class Systematics:
         if self.replacing_config:
             print("WILL USE REPLACE CONFIGURATION FROM '{}'".format(replacing_config))
 
+    def check_expression(self, expression):
+        """function to ensure backwards compatibility. In case weight is defined in the syst csv
+        (WHICH YOU SHOULD NOT DO), this function will return the argument of the definition
+        and will discard the newly defined weight.
+
+        Args:
+            expression (str): expression that needs to be checked
+
+        Returns:
+            str: fully checked expression
+        """
+        if ":=" in expression:
+            expression =  expression.split(":=")[-1]
+        return expression
+
     def construct_syst_dict(self, construct_type):
         syst_dict = OrderedDict()
         systs = self.systematics.loc[self.systematics["Construction"] == construct_type]
@@ -70,7 +85,9 @@ class Systematics:
                 syst_dict.update(self.expand_uncertainties(systematic))
             else:
                 expr_up = self.replaceDummies(systematic["Up"])
+                expr_up = self.check_expression(expr_up)
                 expr_down = self.replaceDummies(systematic["Down"])
+                expr_down = self.check_expression(expr_down)
                 if expr_up == "-" and expr_down == "-":
                     syst_dict[systName] = "-"
                 elif expr_up == "-" or expr_down == "-":
@@ -97,7 +114,9 @@ class Systematics:
         expanded_systs = {}
         systName = syst["Uncertainty"]
         up_variation = self.replaceDummies(syst["Up"])
+        up_variation = self.check_expression(up_variation)
         down_variation = self.replaceDummies(syst["Down"])
+        down_variation = self.check_expression(down_variation)
         syst_variations = {}
         if up_variation == "-" or down_variation == "-":
             syst_variations[systName] = up_variation if not up_variation == "-" else down_variation
@@ -154,7 +173,9 @@ class Systematics:
             names = []
             typ=systematic["Type"]
             up = systematic["Up"]
+            up = self.check_expression(up)
             down = systematic["Down"]
+            down = self.check_expression(down)
             if up == "-" or down == "-":
                 names.append(name)
             else:

--- a/util/tools/Systematics.py
+++ b/util/tools/Systematics.py
@@ -17,7 +17,7 @@ class SystematicsForProcess:
 
 class Systematics:
     def __init__(self,systematicconfig,weightDictionary = {}, replacing_config = None, relevantProcesses = []):
-        print "loading systematics config ..."
+        print("loading systematics config ...")
         self.systematics=pandas.read_csv(systematicconfig,sep=",")
         self.systematics.fillna("-", inplace=True)
         self.relevantProcesses = relevantProcesses
@@ -292,7 +292,7 @@ class Systematics:
                     plotShapes.append(systName)
                 else:
                     plotShapes.append("#"+systName)
-                print systName
+                print (systName)
         return plotShapes
 
     def replaceDummies(self, variationString):

--- a/util/tools/Systematics.py
+++ b/util/tools/Systematics.py
@@ -183,24 +183,24 @@ class Systematics:
                             continue
                         self.processes[process][n]=SystematicsForProcess(n,process,typ,construction,expr)
 
-    # only gets variables to plot, without variation of name with up and down!
-    def plotSystematicsForProcesses(self,list_of_processes):
-        self.processes={}
-        for process in list_of_processes:
-            self.processes[process]={}
-        for i,systematic in self.systematics.iterrows():
-            name=systematic["Uncertainty"]
-            if name.startswith("#"):
-                continue
-            plot=str(systematic["Plot"])
-            if plot=="-":
-                continue
-            typ=systematic["Type"]
-            construction=systematic["Construction"]
-            for process in list_of_processes:
-                if systematic[process] is not "-":
-                    self.processes[process][name]=SystematicsForProcess(name,process,typ,construction,
-                                                                            plot=plot)
+    # # only gets variables to plot, without variation of name with up and down!
+    # def plotSystematicsForProcesses(self,list_of_processes):
+    #     self.processes={}
+    #     for process in list_of_processes:
+    #         self.processes[process]={}
+    #     for i,systematic in self.systematics.iterrows():
+    #         name=systematic["Uncertainty"]
+    #         if name.startswith("#"):
+    #             continue
+    #         plot=str(systematic["Plot"])
+    #         if plot=="-":
+    #             continue
+    #         typ=systematic["Type"]
+    #         construction=systematic["Construction"]
+    #         for process in list_of_processes:
+    #             if systematic[process] is not "-":
+    #                 self.processes[process][name]=SystematicsForProcess(name,process,typ,construction,
+    #                                                                         plot=plot)
 
     #returns weight systematics for specific process
     def get_weight_systs(self,process):
@@ -245,6 +245,49 @@ class Systematics:
         returns list of strings
         """
         return self.__dict_weight_systs.values()
+    
+    def get_all_weight_systs_with_expressions(self):
+        """function to return a dictionary with all weight 
+        systematics and the corresponding expressions.
+        The dictionary contains the weight uncertainties
+        for all relevant processes
+
+        Returns:
+            [dict]: Dictionary for all relevant processes of format
+                    {
+                        "weight_uncertainty_name" : "expression"
+                    }
+        """
+        # init dictionary to return
+        rdict = {}
+        # try to load the dictionary with uncertainties for the 
+        # relevant processes. If this wasn't initialized before, the
+        # property doesn't exist, which is why we try first
+        try:
+            source = self.processes
+            # if this is successful, loop through all the processes and
+            # collect the relevant weight systematics
+            for p in source:
+                # loop through the relevant processes
+                proc_dict = source[p]
+                # loop through the systematics
+                for syst in proc_dict:
+                    # first check that the construction of the entry is
+                    # 'weight'
+                    entry = proc_dict[syst]
+                    if not entry.construction == "weight":
+                        continue
+                    # update the return dictionary. This will also 
+                    # ensure that each systematic is present exactly
+                    # once
+                    rdict.update({syst: entry.expression})
+        except:
+            # if the dictionary with systematics for the relevant processes
+            # is not initialized, use the dictionary with all weight
+            # systematics
+            rdict = self.__dict_weight_systs
+        
+        return rdict
 
     #returns all variation systematics
     def get_all_variation_systs(self):

--- a/util/tools/scriptfunctions.py
+++ b/util/tools/scriptfunctions.py
@@ -614,16 +614,14 @@ def fillHistoSyst(histName, varNames, weight, systNames, systWeights):
     systline_template = " ".join("""helpWeightVec_{histName}.push_back(
         {{  
             {histVectorName}["{histName}{systName}"].get(), 
-            ({systWeight})*(weight_{histName})
+            (weight_expressions["{systName}"])*(weight_{histName})
         }}
     );""".split())
     indent = "        "
     systlines = [indent+systline_template.format(
                                 histVectorName = histVectorName,
                                 histName = histName,
-                                systName = sname,
-                                systWeight = sweight) \
-                for sname, sweight in zip(systNames[1:], systWeights[1:])]
+                                systName = sname) for sname in systNames[1:]]
 
     # Write all individual systnames and systweights in nested vector 
     # to use together with function allowing variadic vector size 

--- a/util/tools/scriptfunctions.py
+++ b/util/tools/scriptfunctions.py
@@ -278,7 +278,7 @@ std::map<std::string, Plot1DInfoStruct> plotinfo1D;
 std::map<std::string, Plot2DInfoStruct> plotinfo2D;
 std::map<std::string, std::unique_ptr<TH1>> histos1D;
 std::map<std::string, std::unique_ptr<TH2>> histos2D;
-""".format(',\n'.join('\t"{}"'.format(c) for c in catnames))
+""".format(',\n'.join(['\t"{}"'.format(c) for c in catnames]))
   for plot in plots:
       if plot.dim == 2:
           title  = plot.histo.GetTitle()+";"+plot.histo.GetXaxis().GetTitle()+";"+plot.histo.GetYaxis().GetTitle()

--- a/util/tools/variableCancer.py
+++ b/util/tools/variableCancer.py
@@ -694,10 +694,11 @@ class Variable:
 
                 self.initError = True
                 print("trying to initialize variable '{}' with itself (var = var) - this does not work".format(self.varName))
-            if "dummyWeight" in self.varName:
-                return "    if(!skipWeightSysts)    "+indent+self.varName+" = "+self.expression+";\n"
-            else:
-                return "    "+indent+self.varName+" = "+self.expression+";\n"
+            # if "dummyWeight" in self.varName:
+            #     return "    if(!skipWeightSysts)    "+indent+self.varName+" = "+self.expression+";\n"
+            # else:
+            #     return "    "+indent+self.varName+" = "+self.expression+";\n"
+            return "    "+indent+self.varName+" = "+self.expression+";\n"
 
 
 


### PR DESCRIPTION
This pull request will solve the problem of producing unnecessary templates in the workflow. Over all, the following changed:
- the plotParallel step will now create a file with the weight systematics for each process, respectively
- weight expressions are initialized in a std::map, no `dummyWeight` syntax necessary anymore
- before initializing/filling the templates, the relevant systematics for the current processes are checked and used
- introduced new classes to easily handle the filling of the templates
This reduces the lines of code significantly - the filling alone was previously around 10xn(Plots)xn(systs) lines, and should now be of the order of 2xn(Plots).

I have tested this with a smaller set of uncertainty and processes, seems to work fine